### PR TITLE
Add simple Node.js Sui wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+wallet.json
+node_modules/
+

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # Crypto Wallet
 
-A simple cryptocurrency wallet application.
+A simple cryptocurrency wallet application. This repository now includes a
+minimal wallet implementation for the Sui blockchain.
 
 ## Features
-- Manage multiple cryptocurrency assets
-- View transaction history
-- Real-time price updates
+- Generate and store an Ed25519 key pair
+- Display the wallet address
+- Sign arbitrary messages
 
 ## Getting Started
-More details coming soon. 
+
+1. Ensure Node.js is installed (version 18 or later).
+2. Run `node src/wallet.js create` to generate a new wallet.
+3. Use `node src/wallet.js address` to view the wallet address.
+4. Sign a message with `node src/wallet.js sign "Hello"`.
+
+Network functions such as querying balances or sending transactions are not
+implemented. This example focuses on key management and signing only.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "crypto-wallet",
+  "version": "1.0.0",
+  "description": "A simple cryptocurrency wallet application.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const crypto = require('crypto');
+
+class SuiWallet {
+  constructor(file = 'wallet.json') {
+    this.file = file;
+    this.keyPair = null;
+  }
+
+  load() {
+    if (fs.existsSync(this.file)) {
+      const data = JSON.parse(fs.readFileSync(this.file));
+      this.keyPair = {
+        publicKey: crypto.createPublicKey({
+          key: Buffer.from(data.publicKey, 'hex'),
+          format: 'der',
+          type: 'spki'
+        }),
+        privateKey: crypto.createPrivateKey({
+          key: Buffer.from(data.privateKey, 'hex'),
+          format: 'der',
+          type: 'pkcs8'
+        })
+      };
+    }
+  }
+
+  save() {
+    if (this.keyPair) {
+      const data = {
+        publicKey: this.keyPair.publicKey
+          .export({ type: 'spki', format: 'der' })
+          .toString('hex'),
+        privateKey: this.keyPair.privateKey
+          .export({ type: 'pkcs8', format: 'der' })
+          .toString('hex'),
+      };
+      fs.writeFileSync(this.file, JSON.stringify(data, null, 2));
+    }
+  }
+
+  create() {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    this.keyPair = { publicKey, privateKey };
+    this.save();
+  }
+
+  address() {
+    if (!this.keyPair) return null;
+    // Simplified address: hex of public key
+    return this.keyPair.publicKey.export({ type: 'spki', format: 'der' }).toString('hex');
+  }
+
+  signMessage(message) {
+    if (!this.keyPair) throw new Error('Wallet not loaded');
+    return crypto.sign(null, Buffer.from(message), this.keyPair.privateKey);
+  }
+}
+
+function main() {
+  const cmd = process.argv[2];
+  const message = process.argv[3];
+  const wallet = new SuiWallet();
+  wallet.load();
+
+  switch (cmd) {
+    case 'create':
+      wallet.create();
+      console.log('New wallet created:', wallet.address());
+      break;
+    case 'address':
+      console.log('Address:', wallet.address());
+      break;
+    case 'sign':
+      if (!message) {
+        console.log('Usage: node src/wallet.js sign <message>');
+        break;
+      }
+      const signature = wallet.signMessage(message);
+      console.log('Signature:', signature.toString('hex'));
+      break;
+    default:
+      console.log('Usage: node src/wallet.js <create|address|sign <message>>');
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { SuiWallet };


### PR DESCRIPTION
## Summary
- initialize Node project files
- implement a small Sui wallet that manages an Ed25519 key pair and signs messages
- document wallet usage in README
- ignore generated wallet file and node modules

## Testing
- `node src/wallet.js create`
- `node src/wallet.js address`
- `node src/wallet.js sign "hello"`
