### PR TITLE
Add Chrome extension wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+wallet.json
+node_modules/
+

--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
 # Crypto Wallet
 
-A simple cryptocurrency wallet application.
+A simple cryptocurrency wallet application. This repository includes a minimal
+wallet implementation for the Sui blockchain along with a small Chrome
+extension so you can experiment in the browser.
 
 ## Features
-- Manage multiple cryptocurrency assets
-- View transaction history
-- Real-time price updates
+- Generate and store an Ed25519 key pair
+- Display the wallet address
+- Sign arbitrary messages and verify signatures
+- Chrome extension popup for easy testing
 
-## Getting Started
-More details coming soon. 
+## Node Usage
+
+1. Ensure Node.js is installed (version 18 or later).
+2. Run `node src/wallet.js create` to generate a new wallet.
+3. Use `node src/wallet.js address` to view the wallet address.
+4. Sign a message with `node src/wallet.js sign "Hello"`.
+5. Verify a signature with `node src/wallet.js verify "Hello" <signature>`.
+
+## Chrome Extension
+
+The `extension/` directory contains a simple Chrome extension that exposes the
+same wallet functionality in a popup.
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select the `extension` folder in this repository.
+4. Click the wallet extension icon and use the popup to create a wallet, sign
+   messages and verify signatures.
+
+Network functions such as querying balances or sending transactions are not
+implemented. This example focuses on key management and signing only.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 3,
+  "name": "Sui Wallet",
+  "version": "1.0",
+  "description": "Simple Sui wallet for key generation and signing.",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": ["storage"]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Sui Wallet</title>
+  <style>
+    body { font-family: sans-serif; width: 300px; padding: 10px; }
+    textarea, input { width: 100%; }
+    button { margin-top: 5px; }
+  </style>
+</head>
+<body>
+  <h1>Sui Wallet</h1>
+  <button id="create">Create Wallet</button>
+  <div>
+    <strong>Address:</strong>
+    <span id="address"></span>
+  </div>
+  <div>
+    <textarea id="message" placeholder="Message"></textarea>
+    <button id="sign">Sign</button>
+    <pre id="signature"></pre>
+  </div>
+  <div>
+    <textarea id="verifyMessage" placeholder="Message to verify"></textarea>
+    <input id="verifySignature" placeholder="Signature hex" />
+    <button id="verify">Verify</button>
+    <div id="verifyResult"></div>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,96 @@
+function bufToHex(buffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBuf(hex) {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return bytes.buffer;
+}
+
+async function loadKeyPair() {
+  const data = await chrome.storage.local.get(['publicKey', 'privateKey']);
+  if (!data.publicKey || !data.privateKey) return null;
+  const publicKey = await crypto.subtle.importKey(
+    'raw',
+    hexToBuf(data.publicKey),
+    { name: 'Ed25519' },
+    false,
+    ['verify']
+  );
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8',
+    hexToBuf(data.privateKey),
+    { name: 'Ed25519' },
+    false,
+    ['sign']
+  );
+  return { publicKey, privateKey, pubHex: data.publicKey };
+}
+
+async function saveKeyPair(keyPair) {
+  const pub = await crypto.subtle.exportKey('raw', keyPair.publicKey);
+  const priv = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
+  await chrome.storage.local.set({
+    publicKey: bufToHex(pub),
+    privateKey: bufToHex(priv)
+  });
+}
+
+async function createWallet() {
+  const keyPair = await crypto.subtle.generateKey(
+    { name: 'Ed25519' },
+    true,
+    ['sign', 'verify']
+  );
+  await saveKeyPair(keyPair);
+  document.getElementById('address').textContent =
+    bufToHex(await crypto.subtle.exportKey('raw', keyPair.publicKey));
+}
+
+async function updateAddress() {
+  const pair = await loadKeyPair();
+  if (pair) {
+    document.getElementById('address').textContent = pair.pubHex;
+  }
+}
+
+async function signMessage() {
+  const pair = await loadKeyPair();
+  if (!pair) {
+    alert('Create a wallet first');
+    return;
+  }
+  const msg = new TextEncoder().encode(document.getElementById('message').value);
+  const signature = await crypto.subtle.sign('Ed25519', pair.privateKey, msg);
+  document.getElementById('signature').textContent = bufToHex(signature);
+}
+
+async function verifyMessage() {
+  const pair = await loadKeyPair();
+  if (!pair) {
+    alert('Create a wallet first');
+    return;
+  }
+  const msg = new TextEncoder().encode(
+    document.getElementById('verifyMessage').value
+  );
+  const sigHex = document.getElementById('verifySignature').value.trim();
+  const valid = await crypto.subtle.verify(
+    'Ed25519',
+    pair.publicKey,
+    hexToBuf(sigHex),
+    msg
+  );
+  document.getElementById('verifyResult').textContent = valid ? 'Valid' : 'Invalid';
+}
+
+document.getElementById('create').addEventListener('click', createWallet);
+document.getElementById('sign').addEventListener('click', signMessage);
+document.getElementById('verify').addEventListener('click', verifyMessage);
+
+updateAddress();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "crypto-wallet",
+  "version": "1.0.0",
+  "description": "A simple cryptocurrency wallet application.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test/wallet.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -1,0 +1,113 @@
+const fs = require('fs').promises;
+const crypto = require('crypto');
+
+class SuiWallet {
+  constructor(file = 'wallet.json') {
+    this.file = file;
+    this.keyPair = null;
+  }
+
+  async load() {
+    try {
+      const data = JSON.parse(await fs.readFile(this.file));
+      this.keyPair = {
+        publicKey: crypto.createPublicKey({
+          key: Buffer.from(data.publicKey, 'hex'),
+          format: 'der',
+          type: 'spki'
+        }),
+        privateKey: crypto.createPrivateKey({
+          key: Buffer.from(data.privateKey, 'hex'),
+          format: 'der',
+          type: 'pkcs8'
+        })
+      };
+    } catch {
+      // ignore if file doesn't exist
+    }
+  }
+
+  async save() {
+    if (!this.keyPair) return;
+    const data = {
+      publicKey: this.keyPair.publicKey
+        .export({ type: 'spki', format: 'der' })
+        .toString('hex'),
+      privateKey: this.keyPair.privateKey
+        .export({ type: 'pkcs8', format: 'der' })
+        .toString('hex')
+    };
+    await fs.writeFile(this.file, JSON.stringify(data, null, 2));
+  }
+
+  async create() {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    this.keyPair = { publicKey, privateKey };
+    await this.save();
+  }
+
+  address() {
+    if (!this.keyPair) return null;
+    return this.keyPair.publicKey
+      .export({ type: 'spki', format: 'der' })
+      .toString('hex');
+  }
+
+  signMessage(message) {
+    if (!this.keyPair) throw new Error('Wallet not loaded');
+    return crypto
+      .sign(null, Buffer.from(message), this.keyPair.privateKey)
+      .toString('hex');
+  }
+
+  verifyMessage(message, signature) {
+    if (!this.keyPair) throw new Error('Wallet not loaded');
+    return crypto.verify(
+      null,
+      Buffer.from(message),
+      this.keyPair.publicKey,
+      Buffer.from(signature, 'hex')
+    );
+  }
+}
+
+async function main() {
+  const [cmd, arg1, arg2] = process.argv.slice(2);
+  const walletPath = process.env.WALLET_PATH || 'wallet.json';
+  const wallet = new SuiWallet(walletPath);
+  await wallet.load();
+
+  switch (cmd) {
+    case 'create':
+      await wallet.create();
+      console.log('New wallet created:', wallet.address());
+      break;
+    case 'address':
+      console.log('Address:', wallet.address());
+      break;
+    case 'sign':
+      if (!arg1) {
+        console.log('Usage: node src/wallet.js sign <message>');
+        break;
+      }
+      console.log('Signature:', wallet.signMessage(arg1));
+      break;
+    case 'verify':
+      if (!arg1 || !arg2) {
+        console.log('Usage: node src/wallet.js verify <message> <signature>');
+        break;
+      }
+      console.log('Valid:', wallet.verifyMessage(arg1, arg2));
+      break;
+    default:
+      console.log(
+        'Usage: node src/wallet.js <create|address|sign|verify> [args]' 
+      );
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { SuiWallet };

--- a/test/wallet.test.js
+++ b/test/wallet.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const fs = require('fs');
+const { SuiWallet } = require('../src/wallet');
+
+(async () => {
+  const file = 'test-wallet.json';
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+  const wallet = new SuiWallet(file);
+  await wallet.create();
+  await wallet.load();
+  assert.ok(wallet.address(), 'address should exist');
+  const msg = 'hello';
+  const sig = wallet.signMessage(msg);
+  assert.ok(sig, 'signature should exist');
+  assert.strictEqual(wallet.verifyMessage(msg, sig), true, 'signature valid');
+  fs.unlinkSync(file);
+  console.log('All tests passed');
+})();


### PR DESCRIPTION
## Summary
- implement a Chrome extension for wallet key management and signing
- rewrite wallet to use async load/save and add verify command
- add minimal unit test

## Testing
- `npm test`
